### PR TITLE
fixed camel^3 errors when submission titles had parantheses

### DIFF
--- a/ssdbot.py
+++ b/ssdbot.py
@@ -109,17 +109,23 @@ def find_ssd(title: str, data):
     category = data.iloc[min(comparison, key=comparison.get), 14]
     index = min(comparison, key=comparison.get) + 2
     storage_match = re.search("(\d+)TB|(\d+)GB|(\d+)tb|(\d+)gb", title)
+    clean_value_dict = {" ": "", "(": "+", ")": ""}
+    camel_url = "https://camelcamelcamel.com/search?sq="
     if storage_match:
         storage = storage_match.group(0)
-        print(storage)
-        camel_url = "https://camelcamelcamel.com/search?sq=" + brand.replace(" ", "") + "+" + model.replace(" ",
-                                                                                                            "") + "+" + storage.replace(
-            " ", "")
+        camel_values = [brand, model, storage]
+        for value in camel_values:
+            for i, j in clean_value_dict.items():
+                value.replace(i, j)
+            camel_url += value
         match = [brand, model, interface, ffactor, capacity, controller, ssd_config, dram,
                  hmb, nand_brand, nand_type, nand_2d_3d, layers, r_w, category, index, camel_url]
     else:
-        camel_url = "https://camelcamelcamel.com/search?sq=" + \
-            brand.replace(" ", "") + "+" + model.replace(" ", "")
+        camel_values = [brand, model]
+        for value in camel_values:
+            for i, j in clean_value_dict.items():
+                value.replace(i, j)
+            camel_url += value
         match = [brand, model, interface, ffactor, capacity, controller, ssd_config, dram,
                  hmb, nand_brand, nand_type, nand_2d_3d, layers, r_w, category, index, camel_url]
     print("[MATCH] Comparison Info: " + str(comparison))


### PR DESCRIPTION
Noticed an issue with some camel links when parentheses were in the submission title. It looks like the end parenthesis was cutting off the reddit formatting for urls. Fixed by replacing "(" with "+" and ")" with "" in brand, model, and (optionally) storage variables while constructing urls.