### PR TITLE
Fix footer markdown

### DIFF
--- a/ssdbot.py
+++ b/ssdbot.py
@@ -72,7 +72,7 @@ def main():
                         f"[Click here to view camelcamelcamel product search page]({ssd[16]})."
                     # Continue adding more to the reply,
                     # specifically the feedback request.
-                    reply += f"\n\n---\n^(Suggestions, concerns, errors? Message us directly or submit an issue on [Github!](https://github.com/ocmarin/ssd-bot))"
+                    reply += f"\n\n---\n^(Suggestions, concerns, errors? Message us directly or submit an issue on) [^(Github!)](https://github.com/ocmarin/ssd-bot)"
                     print("[COMMENT]\n" + reply)
                     # Makes the bot post the comment/reply.
                     if not DEBUG:
@@ -107,7 +107,7 @@ def check_mismatches(reddit: Reddit, user: str, posts: int):
             edit = f"My guess ({guessed}) was **incorrect**. This incident has been recorded." + \
                 "\n\n*Sorry for any confusion, humans!*" + \
                 "\n\n---\n^(Suggestions, concerns, errors? Message us directly or " + \
-                "submit an issue on [Github!](https://github.com/ocmarin/ssd-bot))"
+                "submit an issue on) [^(Github!)](https://github.com/ocmarin/ssd-bot)"
             print(f"[EDIT] {edit}")
             if not DEBUG:
                 comment.edit(edit)


### PR DESCRIPTION
The footer text isn't rendered properly with the link inside of the superscript formatting, due to the way the formatting characters are parsed. This change fixes the markdown so the text renders as intended.
Before-
![image](https://user-images.githubusercontent.com/11672810/105883443-7b357480-5fcc-11eb-8393-092916df8320.png)
After-
![image](https://user-images.githubusercontent.com/11672810/105883480-85577300-5fcc-11eb-83a4-4faf2f3731e1.png)
